### PR TITLE
Removed note for android in Update RN_API.md

### DIFF
--- a/Docs/RN_API.md
+++ b/Docs/RN_API.md
@@ -978,7 +978,7 @@ The code implementation for the conversion listener must be made prior to the in
 ```javascript
 const onInstallConversionDataCanceller = appsFlyer.onInstallConversionData(
   (res) => {
-    if (JSON.parse(res.data.is_first_launch) == true) {
+    if (res.data.is_first_launch) {
       if (res.data.af_status === 'Non-organic') {
         var media_source = res.data.media_source;
         var campaign = res.data.campaign;
@@ -1008,8 +1008,6 @@ appsFlyer.initSdk(/*...*/);
   "type": "onInstallConversionDataLoaded"
 }
 ```
-
- Note** is_first_launch will be "true" (string) on Android and true (boolean) on iOS. To solve this issue wrap is_first_launch with JSON.parse(res.data.is_first_launch) as in the example above.
 
 `appsFlyer.onInstallConversionData` returns a function the will allow us to call `NativeAppEventEmitter.remove()`.<br/>
 


### PR DESCRIPTION
`is_first_launch` is coming through as a boolean on android, so the note is no longer necessary.
However, the type is typed as `'true' | 'false'` so that also needs to be fixed 